### PR TITLE
add vault-transit-engine track

### DIFF
--- a/instruqt-tracks/vault-dynamic-database-credentials/enable-database-secrets-engine/check-vault-mysql-server
+++ b/instruqt-tracks/vault-dynamic-database-credentials/enable-database-secrets-engine/check-vault-mysql-server
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "vault secrets list" /root/.bash_history || fail-message "You haven't listed the Vault secrets engines yet."
+
+grep -q "vault secrets enable -path=lob_a/workshop/database database" /root/.bash_history || fail-message "You haven't enabled the Database secrets engine yet on the path lob_a/workshop/database."
+
+exit 0

--- a/instruqt-tracks/vault-dynamic-database-credentials/enable-database-secrets-engine/solve-vault-mysql-server
+++ b/instruqt-tracks/vault-dynamic-database-credentials/enable-database-secrets-engine/solve-vault-mysql-server
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+# Enable the Database secrets engine
+echo -e "vault secrets enable -path=lob_a/workshop/database database" >> /root/.bash_history
+vault secrets enable -path=lob_a/workshop/database database
+
+exit 0

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -16,7 +16,7 @@ owner: hashicorp
 developers:
 - roger@hashicorp.com
 private: true
-published: false
+published: true
 challenges:
 - slug: enable-database-secrets-engine
   id: z6ovrqxwopus
@@ -28,26 +28,32 @@ challenges:
 
     The Database credentials are time-bound and are automatically revoked when the Vault lease expires. The credentials can also be revoked at any time.
 
-    All secrets engines must be enabled before they can be used. Take a look at what secrets engines are currently enabled.
+    All secrets engines must be enabled before they can be used. Check which secrets engines are currently enabled.
 
     ```
     vault secrets list
     ```
 
-    Note that the Database secrets engine is not enabled. You should enable it.
+    Note that the Database secrets engine is not enabled. Please enable it at the path "lob_a/workshop/database".
 
     ```
-    vault secrets enable database
+    vault secrets enable -path=lob_a/workshop/database database
     ```
   notes:
   - type: text
     contents: |-
-      Secrets engines are components which store, generate, or encrypt data. Secrets engines are incredibly flexible, so it is easiest to think about them in terms of their function.
-
-      Secrets engines are provided some set of data, they take some action on that data, and they return a result.
+      Secrets engines are Vault plugins that store, generate, or encrypt data. Secrets engines are incredibly flexible, so it is easiest to think about them in terms of their function.
 
       Vault's Database secrets engine dynamically generates credentials for many databases.
+
+      To learn more, see these links:
+      https://www.vaultproject.io/docs/secrets/databases/index.html
+      https://www.vaultproject.io/docs/secrets/databases/mysql-maria.html
   tabs:
+  - title: Scripts
+    type: code
+    hostname: vault-mysql-server
+    path: /home/vault/scripts
   - title: Vault CLI
     type: terminal
     hostname: vault-mysql-server
@@ -55,10 +61,6 @@ challenges:
     type: service
     hostname: vault-mysql-server
     port: 8200
-  - title: Web App
-    type: service
-    hostname: vault-mysql-server
-    port: 5000
   difficulty: basic
   timelimit: 600
-checksum: "17791789473690460299"
+checksum: "12623351252262211934"

--- a/instruqt-tracks/vault-transit-engine/config.yml
+++ b/instruqt-tracks/vault-transit-engine/config.yml
@@ -1,0 +1,6 @@
+version: "2"
+virtualmachines:
+- name: vault-mysql-server
+  image: instruqt-hashicorp/vault-with-mysql-and-python-web-app
+  shell: /bin/bash
+  machine_type: n1-standard-1

--- a/instruqt-tracks/vault-transit-engine/enable-transit-engine/check-vault-mysql-server
+++ b/instruqt-tracks/vault-transit-engine/enable-transit-engine/check-vault-mysql-server
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "vault secrets list" /root/.bash_history || fail-message "You haven't listed the Vault secrets engines yet."
+
+grep -q "vault secrets enable -path=lob_a/workshop/transit transit" /root/.bash_history || fail-message "You haven't enabled the Transit secrets engine yet on the path lob_a/workshop/transit."
+
+exit 0

--- a/instruqt-tracks/vault-transit-engine/enable-transit-engine/setup-vault-mysql-server
+++ b/instruqt-tracks/vault-transit-engine/enable-transit-engine/setup-vault-mysql-server
@@ -7,4 +7,8 @@ echo "export MYSQL_PORT=3306" >> $HOME/.bashrc
 echo "export MYSQL_ENDPOINT=localhost:3306" >> $HOME/.bashrc
 echo "export MYSQL_PASSWORD=sJ2w*8NX" >> $HOME/.bashrc
 
+cd /home/vault/transit-app-example/backend
+python3 app.py &>/dev/null &
+cd /root
+
 exit 0

--- a/instruqt-tracks/vault-transit-engine/enable-transit-engine/solve-vault-mysql-server
+++ b/instruqt-tracks/vault-transit-engine/enable-transit-engine/solve-vault-mysql-server
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+# Enable the Transit secrets engine
+echo -e "vault secrets enable -path=lob_a/workshop/transit transit" >> /root/.bash_history
+vault secrets enable -path=lob_a/workshop/transit transit
+
+exit 0

--- a/instruqt-tracks/vault-transit-engine/track.yml
+++ b/instruqt-tracks/vault-transit-engine/track.yml
@@ -1,0 +1,83 @@
+slug: vault-transit-engine
+id: ykk2vp8iivzq
+version: 0.0.1
+type: track
+title: Vault Transit Engine
+teaser: Illustrate the use of Vault's Transit secrets engine to encrypt and decrypt
+  data.
+description: The Vault Transit secrets engine allows Vault to function as an encryption-as-a-service,
+  encrypting and decrypting data stored outside of Vault. In this track, you will
+  use the Transit secrets engine with a Python web app and a MySQL database.
+icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/vault.png
+tags:
+- vault
+- secrets
+- encryption-as-a-service
+owner: hashicorp
+developers:
+- roger@hashicorp.com
+private: true
+published: true
+challenges:
+- slug: enable-transit-engine
+  id: rtt1nujqyebg
+  type: challenge
+  title: Enable the Transit secrets engine
+  teaser: Enable the Transit secrets engine on the Vault server.
+  assignment: |-
+    The Transit secrets engine allows Vault to function as an encryption-as-a-service.
+
+    In this track, you will use the Transit secrets engine with a Python web app that talks to a MySQL server.  Both of these run on the same VM as the Vault server, which is run in "dev" mode with root token set to `root`.
+
+    The web app can be viewed on the "Web App" tab. You'll want to click the icon in the upper right corner of the tabs area to hide the assignment side bar so that you can see the entire UI of the web app. Click it again to see the assignment side bar.
+
+    All secrets engines must be enabled before they can be used. Check which secrets engines are currently enabled.
+    ```
+    vault secrets list
+    ```
+
+    Note that the Transit secrets engine is not enabled. Please enable it at the path "lob_a/workshop/transit".
+
+    ```
+    vault secrets enable -path=lob_a/workshop/transit transit
+    ```
+
+    The PID of the Python web app can be found by running `ps -ef | grep "app.py"`. It can be stopped by running `kill -9 <PID>`.
+
+    It can be restarted in the background with the following commands:
+    ```
+    cd /home/vault/transit-app-example/backend
+    python3 app.py &
+    ```
+    After running those commands, press your `<enter>` or `<return>` key to get your prompt back.
+  notes:
+  - type: text
+    contents: |-
+      Secrets engines are Vault plugins that store, generate, or encrypt data. Secrets engines are incredibly flexible, so it is easiest to think about them in terms of their function.
+
+      Vault's Transit secrets engine functions as Vault's encryption-as-a-service, encrypting and decrypting data stored outside of Vault.
+
+      To learn more, see https://www.vaultproject.io/docs/secrets/transit/index.html.
+  tabs:
+  - title: Scripts
+    type: code
+    hostname: vault-mysql-server
+    path: /home/vault/scripts
+  - title: config.ini
+    type: code
+    hostname: vault-mysql-server
+    path: /home/vault/transit-app-example/backend/config.ini
+  - title: Vault CLI
+    type: terminal
+    hostname: vault-mysql-server
+  - title: Vault UI
+    type: service
+    hostname: vault-mysql-server
+    port: 8200
+  - title: Web App
+    type: service
+    hostname: vault-mysql-server
+    port: 5000
+  difficulty: basic
+  timelimit: 600
+checksum: "2139494378264135690"


### PR DESCRIPTION
I added an initial version of the vault-transit-engine track that can be used to teach students about the Transit secrets engine. It includes uses a GCP VM, instruqt-hashicorp/vault-with-mysql-and-python-web-app, that has Vault 1.3.0, MySQL 5.7, and a Python web app deployed and pre-configured to start.

The setup-vault-mysql-server script under the vault-transit-engine/enable-transit-engine directory sets various MYSQL and VAULT environment variables including the Vault password of root and starts the Python web app on port 5000. The Vault and MySQL servers are automatically started as systemd services running on ports 8200 and 3306 respectively.

Both the Vault UI and the web app are displayed on tabs within the first challenge of the track.

The web app can be viewed on the "Web App" tab. You'll want to click the icon in the upper right corner of the tabs area to hide the assignment side bar so that you can see the entire UI of the web app. Click it again to see the assignment side bar.

Files that students might be asked to run are also visible on the Scripts and config.ini tabs.