### PR TITLE
relax checks to not require quotes

### DIFF
--- a/instruqt-tracks/vault-dynamic-database-credentials/configure-database-secrets-engine/check-vault-mysql-server
+++ b/instruqt-tracks/vault-dynamic-database-credentials/configure-database-secrets-engine/check-vault-mysql-server
@@ -2,7 +2,7 @@
 
 set -e
 
-grep -q "vault write lob_a/workshop/database/config/wsmysqldatabase.*plugin_name=mysql-database-plugin.*connection_url=\"{{username}}:{{password}}@tcp(localhost:3306)/\".*allowed_roles=\"workshop-app\",\"workshop-app-long\".*username=\"hashicorp\".*password=\"Password123\"" /root/.bash_history || fail-message "You haven't configured the wsmysqldatabase connection yet."
+grep -q 'vault write lob_a/workshop/database/config/wsmysqldatabase.*plugin_name=mysql-database-plugin.*connection_url="{{username}}:{{password}}@tcp(localhost:3306)/".*allowed_roles="workshop-app","workshop-app-long".*username="hashicorp".*password="Password123"' /root/.bash_history || fail-message "You haven't configured the wsmysqldatabase connection yet."
 
 grep -q "mysql -u hashicorp -pPassword123" /root/.bash_history || fail-message "You haven't logged into the MySQL server with the 'hashicorp' username yet."
 

--- a/instruqt-tracks/vault-dynamic-database-credentials/generate-database-creds/check-vault-mysql-server
+++ b/instruqt-tracks/vault-dynamic-database-credentials/generate-database-creds/check-vault-mysql-server
@@ -2,7 +2,7 @@
 
 set -e
 
-grep -q "curl --header \"X-Vault-Token: root\" \"http://localhost:8200/v1/lob_a/workshop/database/creds/workshop-app-long\" | jq" /root/.bash_history || fail-message "You haven't generated creds for the workshop-app-long role using the Vault API yet."
+grep -q 'curl --header "X-Vault-Token: root" "http://localhost:8200/v1/lob_a/workshop/database/creds/workshop-app-long" | jq' /root/.bash_history || fail-message "You haven't generated creds for the workshop-app-long role using the Vault API yet."
 
 grep -q "vault read lob_a/workshop/database/creds/workshop-app-long" /root/.bash_history || fail-message "You haven't generated creds for the workshop-app-long role using the Vault CLI yet."
 

--- a/instruqt-tracks/vault-dynamic-database-credentials/renew-revoke-database-creds/check-vault-mysql-server
+++ b/instruqt-tracks/vault-dynamic-database-credentials/renew-revoke-database-creds/check-vault-mysql-server
@@ -4,10 +4,10 @@ set -e
 
 grep -q "vault read lob_a/workshop/database/creds/workshop-app" /root/.bash_history || fail-message "You haven't generated creds for the workshop-app role in this challenge using the Vault CLI yet."
 
-grep -q "vault write sys/leases/renew lease_id=\".*\" increment=\"120\"" /root/.bash_history || fail-message "You haven't renewed the lease for your credentials yet."
+grep -q "vault write sys/leases/renew lease_id=.* increment=" /root/.bash_history || fail-message "You haven't renewed the lease for your credentials yet."
 
-grep -q "vault write sys/leases/lookup lease_id=\".*\"" /root/.bash_history || fail-message "You haven't looked up the lease for your credentials yet."
+grep -q "vault write sys/leases/lookup lease_id=.*" /root/.bash_history || fail-message "You haven't looked up the lease for your credentials yet."
 
-grep -q "vault write sys/leases/revoke lease_id=\".*\"" /root/.bash_history || fail-message "You haven't revoked the lease for your credentials yet."
+grep -q "vault write sys/leases/revoke lease_id=.*" /root/.bash_history || fail-message "You haven't revoked the lease for your credentials yet."
 
 exit 0

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -387,4 +387,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "100757855696202256"
+checksum: "10160173668365095175"


### PR DESCRIPTION
Fixes bug I had in testing the workshop where I didn't have quotes around certain values, and the quotes were being expected by the checks.