### PR TITLE
fix vault links in Vault AWS slides

### DIFF
--- a/docs/slides/aws/vault-oss/aws-auth-method.md
+++ b/docs/slides/aws/vault-oss/aws-auth-method.md
@@ -23,7 +23,7 @@ name: vault-aws-auth-method-1
 # Authenticating to Vault using AWS
 * Auth methods are the components in Vault that perform authentication.
 * They are responsible for assigning identity and policies to users, programs, or machines.
-* Vault's [AWS Auth Method](https://www.vaultproject.io/docs/auth/aws.html) provides an automated mechanism to retrieve a Vault token for IAM principals and AWS EC2 instances.
+* Vault's [AWS Auth Method](https://www.vaultproject.io/docs/auth/aws/) provides an automated mechanism to retrieve a Vault token for IAM principals and AWS EC2 instances.
 * This method securely provides your AWS-based
 applications access to secrets stored in HashiCorp Vault without passwords.
 * It includes two methods: `iam` and `ec2`.

--- a/docs/slides/aws/vault-oss/aws-secrets-engine.md
+++ b/docs/slides/aws/vault-oss/aws-secrets-engine.md
@@ -56,7 +56,7 @@ name: vault-aws-instruqt-tracks
 ---
 name: vault-aws-dynamic-secrets-1
 # Generating Credentials for AWS with Vault
-* The [AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws/index.html) generates AWS access credentials dynamically, based on IAM policies.
+* The [AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws/) generates AWS access credentials dynamically, based on IAM policies.
 * The AWS secrets engine makes working with AWS IAM much easier, since their is no clicking around
 a web UI.
 * Everything can be scripted and automated.
@@ -113,7 +113,7 @@ name: vault-aws-dynamic-secrets-5
 * Most commonly, users leverage the `iam_user` Vault AWS secrets engine.
 * This is what we will do in the lab.
 * For more information on the
-`assumed_role` and `federation_token` secrets engines, review the [STS AssumeRole](https://www.vaultproject.io/docs/secrets/aws/index.html#sts-assumerole) and the [STS Federation Tokens](https://www.vaultproject.io/docs/secrets/aws/index.html#sts-credentials) documentation.
+`assumed_role` and `federation_token` secrets engines, review the [STS AssumeRole](https://www.vaultproject.io/docs/secrets/aws/#sts-assumerole) and the [STS Federation Tokens](https://www.vaultproject.io/docs/secrets/aws/#sts-credentials) documentation.
 
 ---
 name: lab-aws-dynamic-secrets-with-vault


### PR DESCRIPTION
forgot to fix links to Vault pages in the Vault for AWS slides.