### PR TITLE
Update vault version

### DIFF
--- a/instruqt-tracks/vault-aws-auth-method/config.yml
+++ b/instruqt-tracks/vault-aws-auth-method/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.2.3
+  image: vault:1.4.3
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-aws-auth-method/track.yml
+++ b/instruqt-tracks/vault-aws-auth-method/track.yml
@@ -18,7 +18,7 @@ tags:
 - auth-method
 owner: hashicorp
 developers:
-- null
+- neil@hashicorp.com
 private: false
 published: true
 challenges:
@@ -318,4 +318,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "11295441106244509107"
+checksum: "9886731962730280887"

--- a/instruqt-tracks/vault-basics/config.yml
+++ b/instruqt-tracks/vault-basics/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.2.3
+  image: vault:1.4.3
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -390,4 +390,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "2248930275288165673"
+checksum: "6273181162887711081"

--- a/instruqt-tracks/vault-dynamic-database-credentials/config.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-4-3-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -387,4 +387,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "6249267649514863479"
+checksum: "3859884732060993586"

--- a/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.2.3
+  image: vault:1.4.3
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
@@ -13,7 +13,7 @@ tags:
 - dynamic-secrets
 owner: hashicorp
 developers:
-- null
+- neil@hashicorp.com
 private: false
 published: true
 challenges:
@@ -305,4 +305,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "16027906074654382868"
+checksum: "5291309439802120604"

--- a/instruqt-tracks/vault-encryption-as-a-service/config.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-4-3-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-encryption-as-a-service/track.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/track.yml
@@ -218,4 +218,4 @@ challenges:
     path: /home/vault/transit-app-example/backend/config.ini
   difficulty: basic
   timelimit: 1200
-checksum: "10423714370793201742"
+checksum: "17546221620574294795"


### PR DESCRIPTION
I updated the version of Vault used in all 5 Vault workshop Instruqt tracks to 1.4.3.
(This includes the 3 primary tracks and Neil Dahlke's 2 AWS tracks.)