### PR TITLE
add track timer to all tracks

### DIFF
--- a/instruqt-tracks/vault-aws-auth-method/track.yml
+++ b/instruqt-tracks/vault-aws-auth-method/track.yml
@@ -318,4 +318,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "9886731962730280887"
+checksum: "3019046913436166430"
+show_timer: true

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -390,4 +390,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "6273181162887711081"
+checksum: "17861175506067249088"
+show_timer: true

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -387,4 +387,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "3859884732060993586"
+checksum: "10754707837274871451"
+show_timer: true

--- a/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
@@ -305,4 +305,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "5291309439802120604"
+checksum: "16843450083105064757"
+show_timer: true

--- a/instruqt-tracks/vault-encryption-as-a-service/track.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/track.yml
@@ -218,4 +218,5 @@ challenges:
     path: /home/vault/transit-app-example/backend/config.ini
   difficulty: basic
   timelimit: 1200
-checksum: "17546221620574294795"
+checksum: "6003798456707042722"
+show_timer: true


### PR DESCRIPTION
I've added a new Instruqt track timer to all 5 tracks used in this repo.  It will show up above the assignment, letting participants know how much time is left on the whole track (not the challenges which do not time out).