### PR TITLE
make aws tracks private

### DIFF
--- a/instruqt-tracks/vault-aws-auth-method/track.yml
+++ b/instruqt-tracks/vault-aws-auth-method/track.yml
@@ -20,7 +20,7 @@ owner: hashicorp
 developers:
 - neil@hashicorp.com
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:
@@ -320,4 +320,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "7728240530435022026"
+checksum: "17071803439342681053"

--- a/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
@@ -15,7 +15,7 @@ owner: hashicorp
 developers:
 - neil@hashicorp.com
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:
@@ -307,4 +307,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "9253370638236288941"
+checksum: "558886741303255226"


### PR DESCRIPTION
make the AWS tracks that use an AWS account private since Instruqt learned that crypto miners were using it.