### PR TITLE
make vault tracks private

### DIFF
--- a/docs/slides/aws/vault-oss/aws-auth-method.md
+++ b/docs/slides/aws/vault-oss/aws-auth-method.md
@@ -103,10 +103,12 @@ authentication workflow and each can solve different use cases.
 ---
 name: lab-aws-auth-method-for-vault
 # 🔬 Lab: AWS Auth Method for Vault
-This lab uses the Instruqt track, [AWS Auth Method for Vault](https://play.instruqt.com/hashicorp/invite/bict3hvtfqx1).
+This lab uses the Instruqt track, **AWS Auth Method for Vault**.
+
+Your instructor will provide the URL for the track.
 
 #### Lab Summary:
-- Enable the AWS Auth Method
-- Configure the AWS IAM Auth Method
-- Log In Using the AWS IAM Auth Method
-- Log Out of Vault
+- Enabled the AWS Auth Method
+- Configured the AWS IAM Auth Method
+- Logged In Using the AWS IAM Auth Method
+- Logged Out of Vault

--- a/docs/slides/aws/vault-oss/aws-secrets-engine.md
+++ b/docs/slides/aws/vault-oss/aws-secrets-engine.md
@@ -47,9 +47,9 @@ name: vault-aws-instruqt-tracks
 * This workshop uses [Instruqt](https://instruqt.com) for hands-on labs.
 * Instruqt labs are run in "tracks" that are divided into "challenges".
 * This workshop uses the following tracks:
-    1. [AWS Dynamic Secrets with Vault](https://play.instruqt.com/hashicorp/invite/etextvhbaypp)
-    1. [AWS Auth Method for Vault](https://play.instruqt.com/hashicorp/invite/bict3hvtfqx1)
-
+    1. **AWS Dynamic Secrets with Vault**
+    1. **AWS Auth Method for Vault**
+* Your instructor will provide the URL for the tracks.
 ???
 * We will be using Instruqt for the labs.
 
@@ -118,10 +118,10 @@ name: vault-aws-dynamic-secrets-5
 ---
 name: lab-aws-dynamic-secrets-with-vault
 # 🔬 Lab: AWS Dynamic Secrets with Vault
-This lab uses the Instruqt track, [AWS Dynamic Secrets with Vault](https://play.instruqt.com/hashicorp/invite/etextvhbaypp)
+This lab used the Instruqt track, **AWS Dynamic Secrets with Vault**
 
 #### Lab Summary:
-- Enable the AWS Secrets Engine
-- Configure the AWS Secrets Engine
-- Generate AWS Credentials
-- Revoke AWS Credentials
+- Enabled the AWS Secrets Engine
+- Configured the AWS Secrets Engine
+- Generated AWS Credentials
+- Revoked AWS Credentials

--- a/docs/slides/korean/multi-cloud/vault-oss/vault-0.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-0.md
@@ -68,9 +68,9 @@ name: instruqt-tracks
 * 이 워크샵은 [Instruqt](https://instruqt.com)으로 준비되었으며, 실습 과정을 포함합니다.
 * "challenges" 로 구분된 "tracks"에서 Instruqt 실습을 수행합니다.
 * 이번 워크샵에서 사용하는 실습과정은 다음과 같습니다. :
-    1. [Vault Basics](https://play.instruqt.com/hashicorp/invite/qfwncq62zsxu)
-    1. [Vault Dynamic Database Credentials](https://play.instruqt.com/hashicorp/invite/sryhqfdm6sgx)
-    1. [Vault Encryption as a Service](https://play.instruqt.com/hashicorp/invite/qleasfx1dszc)
+    1. **Vault Basics**
+    1. **Vault Dynamic Database Credentials**
+    1. **Vault Encryption as a Service]**
 * 1-6 챕터는 첫번째 실습과정에서 진행됩니다.
 * 7 챕터는 두번째 실습과정에서 진행됩니다.
 * 8 챕터는 세번째 과정에서 진행됩니다.

--- a/docs/slides/korean/multi-cloud/vault-oss/vault-7.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-7.md
@@ -206,7 +206,7 @@ name: lab-database-challenge-1
 # 👩‍💻 Challenge 1: Enable the Engine
 * 이 실습 과제에서는 MySQL 용 데이터베이스 엔진을 활성화하고 루트 자격 증명을 교체합니다.
 
-* [Vault Dynamic Database Credentials](https://play.instruqt.com/hashicorp/invite/sryhqfdm6sgx) Instruqt 트랙에서이 작업을 수행합니다.
+* **Vault Dynamic Database Credentials** Instruqt 트랙에서이 작업을 수행합니다.
 * 지침 :
    * "Vault Dynamic Database Credentials"트랙의 "Enable the Database Secrets Engine"챌린지를 클릭하십시오.
    * 그런 다음 녹색 "시작"버튼을 클릭합니다.

--- a/docs/slides/korean/multi-cloud/vault-oss/vault-8.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-8.md
@@ -137,7 +137,7 @@ name: encryption-key-rotation
 name: lab-transit-challenge-1
 # 👩‍💻 Challenge 1: Enable the Transit Engine
 * 이 실습 챌린지에서는 Transit Engine을 활성화합니다.
-* [Vault Encryption as a Service](https://play.instruqt.com/hashicorp/invite/qleasfx1dszc) Instruqt 트랙에서이 작업을 수행합니다.
+* **Vault Encryption as a Service** Instruqt 트랙에서이 작업을 수행합니다.
 * 지침 :
    * "Vault Encryption as a Service"트랙의 "Enable the Transit Secrets Engine"챌린지를 클릭합니다.
    * 그런 다음 녹색 "시작"버튼을 클릭합니다.

--- a/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
@@ -26,7 +26,7 @@ name: getting-started-with-instruqt
 name: lab-vault-basics-challenge-1
 # 👩‍💻 Challenge 1: The Vault CLI
 * 이 실습에서는 일부 Vault CLI 명령을 실행합니다.
-* [Vault Basics](https://play.instruqt.com/hashicorp/invite/qfwncq62zsxu) Instruqt 트랙의 첫 번째 도전 인 "Vault CLI"에서이 작업을 수행합니다.
+* **Vault Basics** Instruqt 트랙의 첫 번째 도전 인 "Vault CLI"에서이 작업을 수행합니다.
 
 ???
 * Now, you can try running some Vault CLI commands yourself in the first challenge of our first Instruqt track in this workshop.

--- a/docs/slides/multi-cloud/adp/index.md
+++ b/docs/slides/multi-cloud/adp/index.md
@@ -71,6 +71,7 @@ name: environment
   1. (Optional) Vault Transform-Tokenization Secrets Engine
   1. (Optional) Vault Key Management Secrets Engine
   1. Vault KMIP Secrets Engine (Filesystem/Database Level Encryption)
+* Your instructor will provide the URLs for the tracks.
 
 ???
 
@@ -278,7 +279,9 @@ background-image: url(images/HashiCorp-Title-bkg.jpeg)
 # Lab 1: Vault Basics
 In this lab you will cover some basics of Vault like the CLI, GUI, K/V Secrets Engine, and Userpass Auth Method
 
-Lab Link: [Vault Basics](https://play.instruqt.com/hashicorp/invite/qfwncq62zsxu)
+Lab: **Vault Basics**
+
+Your instructor will provide the URL for the track.
 
 ---
 class: title, shelf, no-footer, fullbleed
@@ -371,7 +374,9 @@ background-image: url(images/HashiCorp-Title-bkg.jpeg)
 # Lab Environment
 In this lab we’ll use a MySQL database server that runs on the Vault Server
 
-Lab Link: [Vault Dynamic Database Credentials](https://play.instruqt.com/hashicorp/invite/sryhqfdm6sgx)
+Lab: **Vault Dynamic Database Credentials**
+
+Your instructor will provide the URL for the track.
 
 ---
 # Configuration Steps for MySQL
@@ -469,7 +474,9 @@ In this next Lab we’ll use a web application that leverages both the Transform
 * The “HashiCups” application will leverage Vault’s API to encrypt customer credit card numbers before writing them to the backend database
 * This lab will also showcase data-masking
 
-Lab Link: [Advanced Data Protection with Transform](https://play.instruqt.com/hashicorp/invite/d4b7a8cxjvoe)
+Lab: **Advanced Data Protection with Transform**
+
+Your instructor will provide the URL for the track.
 
 ---
 # Lab 3 Part 2 (Optional)
@@ -477,7 +484,9 @@ In this optional lab, you can leverage a Golang application and the Transform Se
 * The Golang application will leverage Vault’s API to tokenize customer Social Security numbers before writing them to the backend database
 * This lab will also showcase application code modifications as well
 
-Lab Link: [Vault ADP with Tokenization](https://play.instruqt.com/hashicorp/invite/fgbpoajlim0d)
+Lab: **Vault ADP with Tokenization**
+
+Your instructor will provide the URL for the track.
 
 ---
 class: title, shelf, no-footer, fullbleed
@@ -548,8 +557,10 @@ This engine provides a consistent workflow for distribution and lifecycle manage
 
 ---
 # Example KMS workflow (Azure & AWS GA)
-Optional Lab: [Vault Key Management Secrets Engine](https://play.instruqt.com/hashicorp/invite/e3lpvto0tam1)
+Optional Lab: **Vault Key Management Secrets Engine**
 .center[![:scale 100%](images/kms.png)]
+
+Your instructor will provide the URL for the track.
 
 ---
 class: title, shelf, no-footer, fullbleed
@@ -563,7 +574,9 @@ In this next Lab we’ll leverage Vault to act as a KMIP key management server f
 * First we will look at how the data collections would look to an adversary that gains access to the host
 * We will then show how to protect against this threat vector with Vault’s KMIP integration
 
-Lab Link: [Vault KMIP Secrets Engine for MongoDB Encryption](https://play.instruqt.com/hashicorp/invite/h9s9jpxnuuof)
+Lab: **Vault KMIP Secrets Engine for MongoDB Encryption**
+
+Your instructor will provide the URL for the track.
 
 ---
 class: title, shelf, no-footer, fullbleed

--- a/docs/slides/multi-cloud/vault-oss/vault-0.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-0.md
@@ -69,9 +69,11 @@ name: instruqt-tracks
 * This workshop uses [Instruqt](https://instruqt.com) for hands-on labs.
 * Instruqt labs are run in "tracks" that are divided into "challenges".
 * This workshop uses the following tracks:
-    1. [Vault Basics](https://play.instruqt.com/hashicorp/invite/qfwncq62zsxu)
-    1. [Vault Dynamic Database Credentials](https://play.instruqt.com/hashicorp/invite/sryhqfdm6sgx)
-    1. [Vault Encryption as a Service](https://play.instruqt.com/hashicorp/invite/qleasfx1dszc)
+    1. **Vault Basics**
+    1. **Vault Dynamic Database Credentials**
+    1. **Vault Encryption as a Service**
 * We'll cover chapters 1-6 and then do the first lab.
 * We'll then cover chapter 7 with the second lab.
 * We'll finish with chapter 8 and the third lab.
+
+Your instructor will provide the URLs for the tracks.

--- a/docs/slides/multi-cloud/vault-oss/vault-4.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-4.md
@@ -87,7 +87,7 @@ name: vault-kv-engine
 * So, you'll need to enable it yourself.
 
 ???
-* We already used Vault's Key/Value (KV) engine in the second challenge of the "Vault Basics" Instruqt track that had been automatically enabled for the "Dev" mode server.
+* We will use Vault's Key/Value (KV) engine in the second challenge of the "Vault Basics" Instruqt track that will be automatically enabled for the "Dev" mode server.
 * But we'll need to mount it ourselves for the "Prod" mode server.
 
 ---

--- a/docs/slides/multi-cloud/vault-oss/vault-7.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-7.md
@@ -202,7 +202,7 @@ vault write sys/leases/lookup lease_id="<lease_id>"
 name: lab-database-challenge-1
 # 👩‍💻 Challenge 1: Enable the Engine
 * In this lab challenge, you'll enable the database engine for MySQL and rotate its root credentials.
-* You'll do this in the [Vault Dynamic Database Credentials](https://play.instruqt.com/hashicorp/invite/sryhqfdm6sgx) Instruqt track.
+* You'll do this in the **Vault Dynamic Database Credentials** Instruqt track using the link provided by your instructor.
 * Instructions:
   * Click the "Enable the Database Secrets Engine" challenge of the "Vault Dynamic Database Credentials" track.
   * Then click the green "Start" button.

--- a/docs/slides/multi-cloud/vault-oss/vault-8.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-8.md
@@ -135,7 +135,7 @@ name: encryption-key-rotation
 name: lab-transit-challenge-1
 # 👩‍💻 Challenge 1: Enable the Transit Engine
 * In this lab challenge, you'll enable the Transit engine.
-* You'll do this in the [Vault Encryption as a Service](https://play.instruqt.com/hashicorp/invite/qleasfx1dszc) Instruqt track.
+* You'll do this in the **Vault Encryption as a Service** Instruqt track using the link provided by your instructor.
 * Instructions:
   * Click the "Enable the Transit Secrets Engine" challenge of the "Vault Encryption as a Service" track.
   * Then click the green "Start" button.

--- a/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
@@ -18,6 +18,7 @@ name: getting-started-with-instruqt
 * If you've never used Instruqt before, start with this [tutorial](https://play.instruqt.com/instruqt/tracks/getting-started-with-instruqt).
 * Otherwise, you can skip to the next slide.
 * This "Vault Basics" lab covers concepts introduced in chapters 2-6.
+* Your instructor will provide links to the tracks.
 
 ???
 * We'll be using the Instruqt platform for labs in this workshop.
@@ -27,7 +28,7 @@ name: getting-started-with-instruqt
 name: lab-vault-basics-challenge-1
 # 👩‍💻 Challenge 1: The Vault CLI
 * In this lab, you'll run some of the Vault CLI commands.
-* You'll do this in the first challenge, "The Vault CLI", of the [Vault Basics](https://play.instruqt.com/hashicorp/invite/qfwncq62zsxu) Instruqt track.
+* You'll do this in the first challenge, "The Vault CLI", of the **Vault Basics** Instruqt track using the link provided by your instructor.
 
 ???
 * Now, you can try running some Vault CLI commands yourself in the first challenge of our first Instruqt track in this workshop.

--- a/instructor-guides/advanced_data_protection_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/advanced_data_protection_INSTRUCTOR_GUIDE.md
@@ -68,7 +68,7 @@ The slide deck for this training is written completely in [Markdown](https://gui
 https://github.com/hashicorp/field-workshops-vault/issues
 
 ### Hands-on Labs
-At certain points in the slide deck there are links to the lab exercises. [Instruqt](https://instruqt.com/hashicorp) is our lab platform. While all of the Vault workshop tracks (except for https://play.instruqt.com/hashicorp/tracks/vault-advanced-data-protection-with-transform) are actually public, the slides use links to permanent Instruqt invitations that require users to register with Instruqt. We do this so that HashiCorp Field Marketing can collect the emails of users who start tracks during public or private workshops or on their own after following the links from the slides.
+At certain points in the slide deck there are slides about the lab exercises. [Instruqt](https://instruqt.com/hashicorp) is our lab platform. The slides used to have links to permanent Instruqt invitations, but these have been removed. You must now create and share invites with your students for each workshop as described below.
 
 Participants can register with Instruqt [here](https://play.instruqt.com/signup). Users only need to provide an email and a password. They can then login via email, Google, GitHub, and Twitter.=
 
@@ -100,6 +100,16 @@ OPTIONAL TRACK: This track covers the Key Management Secret Engine for AWS.
 
 https://play.instruqt.com/hashicorp/tracks/vault-key-management-secret-engine
 
+#### Creating Instruqt Invites
+Once you've gotten an invite to the HashiCorp organization you can create temporary invite links for your students:
+
+1. Click on the **Invites** link at the top of the page.
+2. Click on the **New+** button to create a new invite.
+3. Create a descriptive title for internal use. Example: "Atlanta Vault ADP Workshop"
+4. Select the tracks you want to make available.
+5. Set the invite to expire in a month or two.
+6. Make the track available to your user for at least a week.
+7. Do not enable **Allow Anonymous** setting if you want to be able to track users progress and emails.
 
 ### Configuring the Instruqt Pools
 We recommend that you configure Instruqt pools for each Instruqt track used in this workshop 1 hour before you plan to use the track. Please see this Confluence [doc](https://hashicorp.atlassian.net/wiki/spaces/SE/pages/511574174/Instruqt+and+Remark+Contributor+Guide#InstruqtandRemarkContributorGuide-ConfiguringInstruqtPools) for instructions.

--- a/instructor-guides/intro_to_vault_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/intro_to_vault_INSTRUCTOR_GUIDE.md
@@ -13,7 +13,7 @@ Prerequisites are minimal. All that is required to participate in the workshop i
 
 The Instruqt tracks include terminal tabs that can be used to execute Vault CLI commands. They also include the Vault UI.
 
-All instructors and TAs from HashiCorp should be sure to register themselves with Instruqt and then post a message in our Slack channel, #proj-instruqt, asking to be added to the HashiCorp organization within Instruqt. This is important even if the tracks are public since only members of the HashiCorp organization can see the useful "Skip to Challenge" button on challenges of tracks within this organization.
+All instructors and TAs from HashiCorp should be sure to register themselves with Instruqt and then post a message in our Slack channel, #proj-instruqt, asking to be added to the HashiCorp organization within Instruqt. This is important since only members of the HashiCorp organization can see the useful "Skip to Challenge" button on challenges of tracks within this organization.
 
 ### Scheduling your workshop
 Please add all workshops, both public and private, to the shared instruqt-workshops Google calendar as follows:
@@ -73,7 +73,7 @@ The slide deck for this training is written completely in [Markdown](https://gui
 https://github.com/hashicorp/field-workshops-vault/issues
 
 ### Hands-on Labs
-At certain points in the slide deck there are links to the lab exercises. [Instruqt](https://instruqt.com/hashicorp) is our lab platform. While all of the Vault workshop tracks are actually public, the slides use links to permanent Instruqt invitations that require users to register with Instruqt. We do this so that HashiCorp Field Marketing can collect the emails of users who start tracks during public or private workshops or on their own after following the links from the slides.
+At certain points in the slide deck there are slides about the lab exercises. [Instruqt](https://instruqt.com/hashicorp) is our lab platform. The slides used to have links to permanent Instruqt invitations, but these have been removed. You must now create and share invites with your students for each workshop as described below.
 
 Participants can register with Instruqt [here](https://play.instruqt.com/signup). Users only need to provide an email and a password. They can then login via email, Google, GitHub, and Twitter.=
 
@@ -104,6 +104,17 @@ Go through this track start to finish and make sure you understand all the chall
 https://play.instruqt.com/hashicorp/tracks/vault-aws-auth-method
 
 Go through this track start to finish and make sure you understand all the challenges. This track covers Vault's AWS auth method.
+
+#### Creating Instruqt Invites
+Once you've gotten an invite to the HashiCorp organization you can create temporary invite links for your students:
+
+1. Click on the **Invites** link at the top of the page.
+2. Click on the **New+** button to create a new invite.
+3. Create a descriptive title for internal use. Example: "Atlanta Vault Basics Workshop"
+4. Select the tracks you want to make available.
+5. Set the invite to expire in a month or two.
+6. Make the track available to your user for at least a week.
+7. Do not enable **Allow Anonymous** setting if you want to be able to track users progress and emails.
 
 ### Configuring the Instruqt Pools
 We recommend that you configure Instruqt pools for each Instruqt track used in this workshop 1 hour before you plan to use the track. Please see this Confluence [doc](https://hashicorp.atlassian.net/wiki/spaces/SE/pages/511574174/Instruqt+and+Remark+Contributor+Guide#InstruqtandRemarkContributorGuide-ConfiguringInstruqtPools) for instructions.

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -16,7 +16,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:
@@ -25,6 +25,23 @@ challenges:
   type: challenge
   title: The Vault CLI
   teaser: Run the Vault Command Line Interface (CLI).
+  notes:
+  - type: text
+    contents: |-
+      Vault open source is a command line application that you can download and run from your laptop or virtual workstation.
+
+      It is written in Go and runs on macOS, Windows, Linux and other operating systems.
+
+      You can always download the latest version of vault here:
+      https://www.vaultproject.io/downloads/
+  - type: text
+    contents: |-
+      Installing Vault on your laptop or workstation is easy. You simply download the zip file, unpack it, and place it somewhere in your PATH.
+
+      Check out this tutorial for step-by-step instructions:
+      https://learn.hashicorp.com/vault/getting-started/install
+
+      We've launched Vault in a Docker container in your Instruqt lab environment so that you don't need to download or install it.
   assignment: |-
     The Vault Command Line Interface (CLI) allows you to interact with Vault servers.
 
@@ -51,23 +68,6 @@ challenges:
     vault read -h
     ```
     Scroll back up to get a feeling for how you would read secrets from Vault.
-  notes:
-  - type: text
-    contents: |-
-      Vault open source is a command line application that you can download and run from your laptop or virtual workstation.
-
-      It is written in Go and runs on macOS, Windows, Linux and other operating systems.
-
-      You can always download the latest version of vault here:
-      https://www.vaultproject.io/downloads/
-  - type: text
-    contents: |-
-      Installing Vault on your laptop or workstation is easy. You simply download the zip file, unpack it, and place it somewhere in your PATH.
-
-      Check out this tutorial for step-by-step instructions:
-      https://learn.hashicorp.com/vault/getting-started/install
-
-      We've launched Vault in a Docker container in your Instruqt lab environment so that you don't need to download or install it.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -79,6 +79,16 @@ challenges:
   type: challenge
   title: Your First Secret
   teaser: Run a Vault dev server and write your first secret.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will run your first Vault server in "dev" mode and write your first secret to Vault.
+
+      See https://www.vaultproject.io/docs/concepts/dev-server/ for more on Vault's "dev" mode.
+
+      You will use the default KV v2 secrets engine that Vault automatically creates in "dev" mode. It is used to store multiple versions of static secrets.
+
+      See https://www.vaultproject.io/docs/secrets/kv/kv-v2/ for more on the KV v2 secrets engine.
   assignment: |-
     There are three tabs to use in this challenge: Vault CLI, Vault Dev Server, and Vault UI.
 
@@ -112,16 +122,6 @@ challenges:
     In the Vault UI tab, select the "secret/" KV v2 secrets engine, select the "my-first-secret" secret, and click the eye icon to see your age.
 
     If you lied about your age, you can correct it in the Vault UI by clicking the "Create new version +" button, or with the Vault CLI by repeating the "vault kv put" command with your real age. Don't worry, nobody else can see it!
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will run your first Vault server in "dev" mode and write your first secret to Vault.
-
-      See https://www.vaultproject.io/docs/concepts/dev-server/ for more on Vault's "dev" mode.
-
-      You will use the default KV v2 secrets engine that Vault automatically creates in "dev" mode. It is used to store multiple versions of static secrets.
-
-      See https://www.vaultproject.io/docs/secrets/kv/kv-v2/ for more on the KV v2 secrets engine.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -140,6 +140,14 @@ challenges:
   type: challenge
   title: The Vault API
   teaser: Use the Vault HTTP API
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will use the Vault HTTP API to check the status of the Vault server you started in the last challenge.
+
+      You will also use the Vault HTTP API to read your age from your "my-first-secret" secret.
+
+      See https://www.vaultproject.io/api-docs/index/ for more on the Vault HTTP API.
   assignment: |-
     In this challenge, you will use the Vault HTTP API.
 
@@ -156,14 +164,6 @@ challenges:
     ```
 
     This should bring back a JSON document showing your age and metadata about the secret including its version.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will use the Vault HTTP API to check the status of the Vault server you started in the last challenge.
-
-      You will also use the Vault HTTP API to read your age from your "my-first-secret" secret.
-
-      See https://www.vaultproject.io/api-docs/index/ for more on the Vault HTTP API.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -175,6 +175,22 @@ challenges:
   type: challenge
   title: Run a Production Server
   teaser: Configure, run, initialize, and unseal a production mode Vault server.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will run a Vault server in "production" mode, initialize it, and unseal it. The server will get its configuration from a file that you will edit before starting it.
+
+      See https://www.vaultproject.io/docs/configuration/ for information on configuring a Vault server.
+
+      See https://www.vaultproject.io/docs/commands/operator/init/ for information on initializing a Vault server.
+
+      See https://www.vaultproject.io/docs/concepts/seal/ for information on the sealing and unsealing of Vault servers.
+  - type: text
+    contents: |-
+      This lab will guide you through initializing and unsealing your Vault server with the Vault CLI.
+
+      But, it is also possible to do both of these in the
+      Vault UI.
   assignment: |-
     Let's run a production Vault sever.
 
@@ -214,22 +230,6 @@ challenges:
     Finally, log into the Vault UI with your root token. If you have problems, double-check that you ran all of the above commands.
 
     <strong>Don't forget to save your root token and unseal key!</strong>
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will run a Vault server in "production" mode, initialize it, and unseal it. The server will get its configuration from a file that you will edit before starting it.
-
-      See https://www.vaultproject.io/docs/configuration/ for information on configuring a Vault server.
-
-      See https://www.vaultproject.io/docs/commands/operator/init/ for information on initializing a Vault server.
-
-      See https://www.vaultproject.io/docs/concepts/seal/ for information on the sealing and unsealing of Vault servers.
-  - type: text
-    contents: |-
-      This lab will guide you through initializing and unsealing your Vault server with the Vault CLI.
-
-      But, it is also possible to do both of these in the
-      Vault UI.
   tabs:
   - title: Vault Configuration
     type: code
@@ -252,6 +252,19 @@ challenges:
   type: challenge
   title: Use the KV V2 Secrets Engine
   teaser: Enable and use an instance of the KV v2 Secrets engine.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will mount an instance of Vault's KV v2 secrets engine on the Vault production server you started in the previous challenge.
+
+      You will also write a secret, change its value in the Vault UI, and then see that you can still inspect its original value since the KV v2 secrets engine maintains multiple versions of secrets.
+  - type: text
+    contents: |-
+      See https://www.vaultproject.io/docs/secrets/ to learn about Vault secrets engines.
+
+      See https://www.vaultproject.io/docs/secrets/kv/ to learn about Vault's KV secrets engine. You will use version 2 of this engine which can retain multiple versions of any secret.
+
+      See https://www.vaultproject.io/docs/commands/secrets/enable/ for information about the `vault secrets enable` command.
   assignment: |-
     Now that you have a Vault production server running (in the background), you can mount a secrets engine and write secrets to it.
 
@@ -273,19 +286,6 @@ challenges:
     Change the value in the UI by clicking the "Create new version +" button, typing a new value in the field with the dots, and clicking the "Save" button.  Click the eye icon for the secret to validate the change.
 
     Still in the Vault UI, select the History menu for the secret, select "Version 1", and click the eye icon again to see the original value.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will mount an instance of Vault's KV v2 secrets engine on the Vault production server you started in the previous challenge.
-
-      You will also write a secret, change its value in the Vault UI, and then see that you can still inspect its original value since the KV v2 secrets engine maintains multiple versions of secrets.
-  - type: text
-    contents: |-
-      See https://www.vaultproject.io/docs/secrets/ to learn about Vault secrets engines.
-
-      See https://www.vaultproject.io/docs/secrets/kv/ to learn about Vault's KV secrets engine. You will use version 2 of this engine which can retain multiple versions of any secret.
-
-      See https://www.vaultproject.io/docs/commands/secrets/enable/ for information about the `vault secrets enable` command.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -301,6 +301,19 @@ challenges:
   type: challenge
   title: Use the Userpass Auth Method
   teaser: Enable and use the userpass authentication method.
+  notes:
+  - type: text
+    contents: |-
+      Now that you have a running production Vault server with a KV v2 secrets engine mounted, it's time to learn how to authenticate users.
+
+      In this challenge, you'll mount and use the Userpass auth method which allows users to authenticate to Vault with usernames and passwords managed by Vault.
+
+      You'll also start to learn about Vault policies that restrict which secrets different users and applications can read and write. Note that Vault policies are "deny by default"; this means a token can only read or write secrets if explicitly given permission to do so by one of the policies attached to it.
+  - type: text
+    contents: |-
+      See https://www.vaultproject.io/docs/auth/ to learn about Vault auth methods.
+
+      See https://www.vaultproject.io/docs/auth/userpass/ to learn about Vault's Userpass auth method.
   assignment: |-
     Now that you have a running production Vault server with a KV v2 secrets engine mounted, it's time to learn how to authenticate users.
 
@@ -338,19 +351,6 @@ challenges:
     You will get an error message because your token is not authorized to read any secrets yet.  That is because Vault policies are "deny by default", meaning that a token can only read or write a secret if it is explicitly given permission to do so by one of its policies.
 
     In the next challenge, you'll add a policy to your username that will allow you to read and write some secrets.
-  notes:
-  - type: text
-    contents: |-
-      Now that you have a running production Vault server with a KV v2 secrets engine mounted, it's time to learn how to authenticate users.
-
-      In this challenge, you'll mount and use the Userpass auth method which allows users to authenticate to Vault with usernames and passwords managed by Vault.
-
-      You'll also start to learn about Vault policies that restrict which secrets different users and applications can read and write. Note that Vault policies are "deny by default"; this means a token can only read or write secrets if explicitly given permission to do so by one of the policies attached to it.
-  - type: text
-    contents: |-
-      See https://www.vaultproject.io/docs/auth/ to learn about Vault auth methods.
-
-      See https://www.vaultproject.io/docs/auth/userpass/ to learn about Vault's Userpass auth method.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -366,6 +366,12 @@ challenges:
   type: challenge
   title: Use Vault Policies
   teaser: Use Vault policies to grant different users access to different secrets.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you'll define Vault policies to give two different users access to different secrets within Vault.
+
+      See https://www.vaultproject.io/docs/concepts/policies/ to learn about Vault policies.
   assignment: |-
     Now that you have the Userpass authentication method configured, you can add policies to give different users access to different secrets.
 
@@ -411,12 +417,6 @@ challenges:
     The bottom line for this challenge is that Vault protects each user's secrets from other users.
 
     <strong>Congratulations on finishing the entire track!</strong>
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you'll define Vault policies to give two different users access to different secrets within Vault.
-
-      See https://www.vaultproject.io/docs/concepts/policies/ to learn about Vault policies.
   tabs:
   - title: Vault Policies
     type: code
@@ -431,4 +431,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 900
-checksum: "2632024856703108042"
+checksum: "11758291419114857693"

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -17,7 +17,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:
@@ -27,6 +27,16 @@ challenges:
   title: Enable the Database Secrets Engine
   teaser: |
     Enable the Database secrets engine on the Vault server.
+  notes:
+  - type: text
+    contents: |-
+      Secrets engines are Vault plugins that store, generate, or encrypt data. Secrets engines are incredibly flexible, so it is easiest to think about them in terms of their function.
+
+      Vault's Database secrets engine dynamically generates credentials for many databases.
+
+      To learn more, see these links:
+      https://www.vaultproject.io/docs/secrets/databases/
+      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
   assignment: |-
     The Database secrets engine generates credentials dynamically for various databases.  In this track, we are using an instance of MySQL that is running on the same VM as the Vault server itself.
 
@@ -43,16 +53,6 @@ challenges:
     ```
 
     If you like, you can login to the Vault UI with the Vault token `root` and see that the database secrets engine has been enabled.
-  notes:
-  - type: text
-    contents: |-
-      Secrets engines are Vault plugins that store, generate, or encrypt data. Secrets engines are incredibly flexible, so it is easiest to think about them in terms of their function.
-
-      Vault's Database secrets engine dynamically generates credentials for many databases.
-
-      To learn more, see these links:
-      https://www.vaultproject.io/docs/secrets/databases/
-      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
   tabs:
   - title: Vault CLI
     type: terminal
@@ -69,6 +69,23 @@ challenges:
   title: Configure the Database Secrets Engine
   teaser: |
     Configure the Database secrets engine on the Vault server.
+  notes:
+  - type: text
+    contents: |-
+      Vault's Database secrets engine dynamically generates credentials (username and password) for many databases.
+
+      In this challenge, you will configure the database secrets engine you enabled in the previous challenge on the path `lob_a/workshop/database` to work with the local instance of the MySQL database. We use a specific path rather than the default "database" to illustrate that multiple instances of the database secrets engine could be configured for different lines of business that might each have multiple databases.
+  - type: text
+    contents: |-
+      We will configure a connection and two roles for the database. The roles will allow dynamic generation of credentials with different lifetimes.
+
+      The first role, "workshop-app-long", will generate credentials initially valid for 1 hour with a maximum lifetime of 24 hours. The second role, "workshop-app", will generate credentials initially valid for 3 minutes with a maximum lifetime of 6 minutes.
+
+      To learn more, see these links:
+      https://www.vaultproject.io/docs/secrets/databases/
+      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
+      https://www.vaultproject.io/api/secret/databases/
+      https://www.vaultproject.io/api/secret/databases/mysql-maria/
   assignment: |-
     All secrets engines must be configured before they can be used.
 
@@ -133,23 +150,6 @@ challenges:
     This should return "Success! Data written to: lob_a/workshop/database/roles/workshop-app".
 
     The database secrets engine is now configured to talk to the MySQL server and is allowed to create users with two different roles. In the next challenge, you'll generate credentials (username and password) for these roles.
-  notes:
-  - type: text
-    contents: |-
-      Vault's Database secrets engine dynamically generates credentials (username and password) for many databases.
-
-      In this challenge, you will configure the database secrets engine you enabled in the previous challenge on the path `lob_a/workshop/database` to work with the local instance of the MySQL database. We use a specific path rather than the default "database" to illustrate that multiple instances of the database secrets engine could be configured for different lines of business that might each have multiple databases.
-  - type: text
-    contents: |-
-      We will configure a connection and two roles for the database. The roles will allow dynamic generation of credentials with different lifetimes.
-
-      The first role, "workshop-app-long", will generate credentials initially valid for 1 hour with a maximum lifetime of 24 hours. The second role, "workshop-app", will generate credentials initially valid for 3 minutes with a maximum lifetime of 6 minutes.
-
-      To learn more, see these links:
-      https://www.vaultproject.io/docs/secrets/databases/
-      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
-      https://www.vaultproject.io/api/secret/databases/
-      https://www.vaultproject.io/api/secret/databases/mysql-maria/
   tabs:
   - title: Vault CLI
     type: terminal
@@ -166,6 +166,17 @@ challenges:
   title: Generate and Use Dynamic Database Credentials
   teaser: |
     Generate and use dynamic database credentials for the MySQL database.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will dynamically generate credentials (username and password) against the two roles you configured in the previous challenge.
+
+      You will then connect to the MySQL server with the credentials generated against the shorter duration role, "workshop-app". You will also validate that Vault deletes the credentials from the MySQL server after 3 minutes.
+
+      To learn more, see these links:
+      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
+      https://www.vaultproject.io/docs/secrets/databases/#usage
+      https://www.vaultproject.io/api/secret/databases/#generate-credentials
   assignment: |-
     Now that you have configured the database secrets engine with a connection and two roles for the MySQL database, you can dynamically generate short-lived credentials against the roles and use them to connect to the database.
 
@@ -268,17 +279,6 @@ challenges:
     This shows that Vault deleted the credentials from the MySQL database when the lease of the credentials expired after 3 minutes.
 
     In the next challenge, you will learn how to renew and revoke database credentials.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will dynamically generate credentials (username and password) against the two roles you configured in the previous challenge.
-
-      You will then connect to the MySQL server with the credentials generated against the shorter duration role, "workshop-app". You will also validate that Vault deletes the credentials from the MySQL server after 3 minutes.
-
-      To learn more, see these links:
-      https://www.vaultproject.io/docs/secrets/databases/mysql-maria/
-      https://www.vaultproject.io/docs/secrets/databases/#usage
-      https://www.vaultproject.io/api/secret/databases/#generate-credentials
   tabs:
   - title: Vault CLI
     type: terminal
@@ -295,6 +295,16 @@ challenges:
   title: Renew and Revoke Database Credentials
   teaser: |
     Renew and revoke database credentials for the MySQL database.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will learn how to renew and revoke credentials generated by Vault's database secrets engine.
+
+      You will see that it is possible to extend the lifetime of generated credentials when they have not yet expired by renewing them. You will also see that they cannot be renewed beyond the `max_ttl` of the role against which the credentials were generated.
+
+      To learn more, see these links:
+      https://www.vaultproject.io/api/system/leases/#renew-lease
+      https://www.vaultproject.io/api/system/leases/#revoke-lease
   assignment: |-
     In addition to using Vault's database secrets engine to generate credentials for databases, you can also use it to extend their lifetime or revoke them.
 
@@ -365,16 +375,6 @@ challenges:
     replacing `<username>` with the generated username and providing the generated password when prompted. You should see a mesage including "ERROR 1045 (28000): Access denied for user".
 
     Congratulations on finishing the Vault Dynamic Database Credentials track.  We recommend that you explore the [Vault Transit Engine](https://instruqt.com/hashicorp/tracks/vault-transit-engine) track next.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will learn how to renew and revoke credentials generated by Vault's database secrets engine.
-
-      You will see that it is possible to extend the lifetime of generated credentials when they have not yet expired by renewing them. You will also see that they cannot be renewed beyond the `max_ttl` of the role against which the credentials were generated.
-
-      To learn more, see these links:
-      https://www.vaultproject.io/api/system/leases/#renew-lease
-      https://www.vaultproject.io/api/system/leases/#revoke-lease
   tabs:
   - title: Vault CLI
     type: terminal
@@ -385,4 +385,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "139651996433050068"
+checksum: "9681375624736018115"

--- a/instruqt-tracks/vault-encryption-as-a-service/track.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/track.yml
@@ -17,7 +17,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:
@@ -27,6 +27,16 @@ challenges:
   title: Enable the Transit Secrets Engine
   teaser: |
     Enable the Transit secrets engine on the Vault server to enable Vault's Encryption-as-a-Service.
+  notes:
+  - type: text
+    contents: |-
+      Secrets engines are Vault plugins that store, generate, or encrypt data.
+
+      Vault's Transit secrets engine functions as Vault's Encryption-as-a-Service, encrypting and decrypting data stored outside of Vault.
+
+      In this track, you'll see how the Transit engine can encrypt and decrypt data stored in a MySQL database.
+
+      To learn more, see https://www.vaultproject.io/docs/secrets/transit/.
   assignment: |-
     The Transit secrets engine allows Vault to function as an encryption-as-a-service.
 
@@ -45,16 +55,6 @@ challenges:
     ```
 
     Other lines of busines could create their own instances of the Transit engine.
-  notes:
-  - type: text
-    contents: |-
-      Secrets engines are Vault plugins that store, generate, or encrypt data.
-
-      Vault's Transit secrets engine functions as Vault's Encryption-as-a-Service, encrypting and decrypting data stored outside of Vault.
-
-      In this track, you'll see how the Transit engine can encrypt and decrypt data stored in a MySQL database.
-
-      To learn more, see https://www.vaultproject.io/docs/secrets/transit/.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -75,6 +75,13 @@ challenges:
   title: Create a Key for the Transit Secrets Engine
   teaser: |
     Create an encryption key for the Transit secrets engine on the Vault server so that it can encrypt and decrypt data stored outside of Vault.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will create an encryption key that the Transit engine you created in the previous challenge will use to encrypt and decrypt sensitive data in the MySQL database running on the Vault server.
+
+      To learn more about the types of encryption keys that the Transit engine supports, see:
+      https://www.vaultproject.io/docs/secrets/transit/#key-types
   assignment: |-
     In order to use the Transit secrets engine, you need to create at least one encryption key to use with it.
 
@@ -84,13 +91,6 @@ challenges:
     ```
 
     That was easy!
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will create an encryption key that the Transit engine you created in the previous challenge will use to encrypt and decrypt sensitive data in the MySQL database running on the Vault server.
-
-      To learn more about the types of encryption keys that the Transit engine supports, see:
-      https://www.vaultproject.io/docs/secrets/transit/#key-types
   tabs:
   - title: Vault CLI
     type: terminal
@@ -111,6 +111,12 @@ challenges:
   title: Use the Web App Without Vault
   teaser: |
     Use the python web application without Vault. This will allow users to see sensitive data when looking at database rows.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will use the Python web application without Vault enabled.
+
+      You will add a record to the database and see that the data is not encrypted. The database user and password are hard-coded in a configuration file.
   assignment: |-
     The web app can be viewed on the "Web App" tab. You'll want to click the icon in the upper right corner of the tabs area to hide the assignment window so that you can see the entire UI of the web app. Click it again to display the assignment window.
 
@@ -128,12 +134,6 @@ challenges:
     Without Vault, the web app gets a username and password for talking to the MySQL database from a file "config.ini" in the directory /home/vault/transit-app-example/backend. Specifically, the "User" field specifies "root" as the database user while the "Password" field gives the original password for the root user, "sJ2w*8NX". In the next challenge, the web app will retrieve a username and password dynamically generated from Vault's Database secrets engine.
 
     In the next challenge, you'll enable Vault for the application and see the Transit engine in action.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will use the Python web application without Vault enabled.
-
-      You will add a record to the database and see that the data is not encrypted. The database user and password are hard-coded in a configuration file.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -154,6 +154,14 @@ challenges:
   title: Use the Web App With Vault
   teaser: |
     Use the python web application with Vault. This will prevent users from seeing sensitive data when looking at new database rows.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will use the Python web application with Vault enabled. You will add a record to the database and see that the new data **is** encrypted.
+
+      As a bonus, you'll see that the web app is now logging into the MySQL database that stores its data with short-lived credentials retrieved from Vault's Database secrets engine. These credentials are dynamically generated on the fly when the app is started.
+
+      Finally, you'll use the Vault UI to rotate the Transit engine's "customer-key" encryption key. You'll see that the web app uses the new key for encrypting and decrypting new records but can still use the original key to decyrpt older records.
   assignment: |-
     In this challenge, you will stop the Python web app, edit its configuration file to use Vault, and see how new records are encrypted by Vault's Transit engine.
 
@@ -193,14 +201,6 @@ challenges:
     Go back to the web app, add another record, and then look at the record in the Database View. Verify that is is also encrypted.  Note that the first record you added after enabling Vault and the Transit engine has encrypted fields with encrypted values starting with "vault:v1" while the new record has fields with encrypted values starting with "vault:v2".
 
     Vault used the new version of the key to encrypt the new record. Someone with the old version of the key could not decrypt this new record.  But Vault can still decrypt the older record that was encrypted with the first version of the key. Finally, if desired, data encrypted with an older version of the key can be rewrapped with the newest version using the Transit engine's `rewrap` endpoint.
-  notes:
-  - type: text
-    contents: |-
-      In this challenge, you will use the Python web application with Vault enabled. You will add a record to the database and see that the new data **is** encrypted.
-
-      As a bonus, you'll see that the web app is now logging into the MySQL database that stores its data with short-lived credentials retrieved from Vault's Database secrets engine. These credentials are dynamically generated on the fly when the app is started.
-
-      Finally, you'll use the Vault UI to rotate the Transit engine's "customer-key" encryption key. You'll see that the web app uses the new key for encrypting and decrypting new records but can still use the original key to decyrpt older records.
   tabs:
   - title: Vault CLI
     type: terminal
@@ -219,4 +219,4 @@ challenges:
     path: /home/vault/transit-app-example/backend/config.ini
   difficulty: basic
   timelimit: 1200
-checksum: "7989254489339558106"
+checksum: "16822224126488059853"


### PR DESCRIPTION
This makes all Vault workshop tracks private.  It also removes embedded links to invites to those tracks and add notes saying that instructors will provide links to the tracks.  The instructor guides have also been updated.