### PR TITLE
update to vault 1.8.3

### DIFF
--- a/instruqt-tracks/vault-aws-auth-method/config.yml
+++ b/instruqt-tracks/vault-aws-auth-method/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.7.3
+  image: vault:1.8.3
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-aws-auth-method/track.yml
+++ b/instruqt-tracks/vault-aws-auth-method/track.yml
@@ -1,5 +1,6 @@
 slug: vault-aws-auth-method
 id: fe9wq4sopgrc
+version: 1.8.3
 type: track
 title: AWS Auth Method for Vault
 teaser: Authenticate to Vault using the AWS Auth Method for IAM.
@@ -91,8 +92,7 @@ challenges:
   id: 4fnz9dgdhnfd
   type: challenge
   title: Configure the AWS IAM Auth Method
-  teaser: Configures the credentials required to perform successful API calls to AWS
-    from Vault.
+  teaser: Configures the credentials required to perform successful API calls to AWS from Vault.
   notes:
   - type: text
     contents: |-
@@ -195,8 +195,7 @@ challenges:
   id: cgaexaj1xjpe
   type: challenge
   title: Log In Using the AWS IAM Auth Method
-  teaser: Generate a signed AWS API request that will validate against AWS and log
-    you into Vault.
+  teaser: Generate a signed AWS API request that will validate against AWS and log you into Vault.
   notes:
   - type: text
     contents: |-
@@ -320,4 +319,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "11233284371291168260"
+checksum: "2139607513904076653"
+_: ""

--- a/instruqt-tracks/vault-basics-korean/config.yml
+++ b/instruqt-tracks/vault-basics-korean/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.6.2
+  image: vault:1.8.3
   cmd: version
   shell: /bin/sh -l
   ports:

--- a/instruqt-tracks/vault-basics-korean/track.yml
+++ b/instruqt-tracks/vault-basics-korean/track.yml
@@ -449,4 +449,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 900
-checksum: "5755708950870893048"
+checksum: "9602933576889613302"
+_: ""

--- a/instruqt-tracks/vault-basics/config.yml
+++ b/instruqt-tracks/vault-basics/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.6.2
+  image: vault:1.8.3
   cmd: version
   shell: /bin/sh -l
   ports:

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -1,5 +1,6 @@
 slug: vault-basics
 id: likpqjspv5pp
+version: 1.8.3
 type: track
 title: Vault Basics
 teaser: Learn how to setup and run a Vault server and manage its secrets.
@@ -39,7 +40,7 @@ challenges:
       Installing Vault on your laptop or workstation is easy. You simply download the zip file, unpack it, and place it somewhere in your PATH.
 
       Check out this tutorial for step-by-step instructions:
-      https://learn.hashicorp.com/vault/getting-started/install
+      https://learn.hashicorp.com/tutorials/vault/getting-started-install
 
       We've launched Vault in a Docker container in your Instruqt lab environment so that you don't need to download or install it.
   assignment: |-
@@ -147,7 +148,7 @@ challenges:
 
       You will also use the Vault HTTP API to read your age from your "my-first-secret" secret.
 
-      See https://www.vaultproject.io/api-docs/index/ for more on the Vault HTTP API.
+      See https://www.vaultproject.io/api-docs/ for more on the Vault HTTP API.
   assignment: |-
     In this challenge, you will use the Vault HTTP API.
 
@@ -431,4 +432,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 900
-checksum: "11758291419114857693"
+checksum: "10671294877937963932"
+_: ""

--- a/instruqt-tracks/vault-dynamic-database-credentials/config.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-1-6-2-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-8-3-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -1,6 +1,6 @@
 slug: vault-dynamic-database-credentials
 id: hbtxgbf9n1nt
-version: 0.0.1
+version: 1.8.3
 type: track
 title: Vault Dynamic Database Credentials
 teaser: |
@@ -347,7 +347,7 @@ challenges:
     issue_time      2019-12-12T17:49:41.267656019Z
     last_renewal    <nil>
     renewable       true
-    ttl             4m31s
+    ttl             1m45s
     ```
 
     The `ttl` will tell you the remaining time to live of the lease and the credentials. When the lease expires, Vault will delete the credentials from MySQL.
@@ -385,4 +385,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "9681375624736018115"
+checksum: "2947793928319853135"
+_: ""

--- a/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.7.3
+  image: vault:1.8.3
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
@@ -1,5 +1,6 @@
 slug: vault-aws-dynamic-secrets
 id: avjxhl9qqgau
+version: 1.8.3
 type: track
 title: AWS Dynamic Secrets with Vault
 teaser: Generate AWS credentials dynamically based on IAM policies.
@@ -24,6 +25,13 @@ challenges:
   type: challenge
   title: Enable the AWS Secrets Engine
   teaser: Prepare Vault to generate dynamic credentials for AWS.
+  notes:
+  - type: text
+    contents: |-
+      Secrets engines are components which store, generate, or encrypt data. Secrets engines
+      are incredibly flexible, so it is easiest to think about them in terms of their function.
+      Secrets engines are provided some set of data, they take some action on that data, and
+      they return a result.
   assignment: |-
     The AWS secrets engine generates AWS access credentials dynamically based on
     IAM policies. This generally makes working with AWS IAM easier, since it does
@@ -71,13 +79,6 @@ challenges:
 
     If you open up the Vault UI tab and use this token, you can log into the UI and
     take a look around.
-  notes:
-  - type: text
-    contents: |-
-      Secrets engines are components which store, generate, or encrypt data. Secrets engines
-      are incredibly flexible, so it is easiest to think about them in terms of their function.
-      Secrets engines are provided some set of data, they take some action on that data, and
-      they return a result.
   tabs:
   - title: Enable the AWS Secrets Engine
     type: terminal
@@ -93,6 +94,15 @@ challenges:
   type: challenge
   title: Configure the AWS Secrets Engine
   teaser: Prepare Vault to generate dynamic AWS credentials.
+  notes:
+  - type: text
+    contents: |-
+      Most secrets engines must be configured in advance before they can perform their
+      functions. Vault supports three different types of credentials to retrieve from AWS.
+
+      This track focuses on the [`iam_user`](https://www.vaultproject.io/docs/secrets/aws/#iam_user)
+      method, however, you can read more about the
+      [other options](https://www.vaultproject.io/docs/secrets/aws/).
   assignment: |-
     After enabling the AWS secrets engine, you must configure it to authenticate and
     communicate with AWS. You have been provided AWS credentials, so no need to use
@@ -155,15 +165,6 @@ challenges:
     }
     EOF
     ```
-  notes:
-  - type: text
-    contents: |-
-      Most secrets engines must be configured in advance before they can perform their
-      functions. Vault supports three different types of credentials to retrieve from AWS.
-
-      This track focuses on the [`iam_user`](https://www.vaultproject.io/docs/secrets/aws/#iam_user)
-      method, however, you can read more about the
-      [other options](https://www.vaultproject.io/docs/secrets/aws/).
   tabs:
   - title: Configure the AWS Secrets Engine
     type: terminal
@@ -179,6 +180,12 @@ challenges:
   type: challenge
   title: Generate AWS Credentials
   teaser: Generate AWS access key pairs on the fly.
+  notes:
+  - type: text
+    contents: |-
+      Dynamic secrets are generated when they are accessed. Dynamic secrets do not
+      exist until they are read, so there is no risk of someone stealing them or
+      another client using the same secrets.
   assignment: |-
     In the last challenge you told Vault "when I ask for a credential for `my-role`,
     create it and attach the IAM policy `{ "Version": "2012..." }`"".
@@ -223,12 +230,6 @@ challenges:
     ```
     vault list sys/leases/lookup/aws/creds/my-role
     ```
-  notes:
-  - type: text
-    contents: |-
-      Dynamic secrets are generated when they are accessed. Dynamic secrets do not
-      exist until they are read, so there is no risk of someone stealing them or
-      another client using the same secrets.
   tabs:
   - title: Generate AWS Credentials
     type: terminal
@@ -244,6 +245,11 @@ challenges:
   type: challenge
   title: Revoke AWS Credentials
   teaser: Revoke the dynamically generated AWS access key pairs.
+  notes:
+  - type: text
+    contents: |-
+      Because Vault has built-in revocation mechanisms, dynamic secrets can be
+      revoked immediately after use, minimizing the amount of time the secret existed.
   assignment: |-
     Vault will automatically revoke this credential after 30 minutes as we configured,
     but perhaps you want to revoke it early. Once the secret is revoked, the access keys
@@ -292,11 +298,6 @@ challenges:
     With such easy dynamic creation and revocation, you can hopefully begin
     to see how easy it is to work with dynamic secrets and ensure they only
     exist for the duration that they are needed.
-  notes:
-  - type: text
-    contents: |-
-      Because Vault has built-in revocation mechanisms, dynamic secrets can be
-      revoked immediately after use, minimizing the amount of time the secret existed.
   tabs:
   - title: Revoke AWS Credentials
     type: terminal
@@ -307,4 +308,5 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "558886741303255226"
+checksum: "17227856681745187198"
+_: ""

--- a/instruqt-tracks/vault-encryption-as-a-service/config.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-1-6-2-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-8-3-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-encryption-as-a-service/enable-transit-engine/setup-vault-mysql-server
+++ b/instruqt-tracks/vault-encryption-as-a-service/enable-transit-engine/setup-vault-mysql-server
@@ -178,6 +178,10 @@ if __name__ == '__main__':
     logging.error("There was an error starting the server: {}".format(e))
 EOF
 
+# Fix Vault icon
+sed -i 's/https:\/\/s3\.amazonaws\.com\/hashicorp-marketing-web-assets\/brand\/Vault_VerticalLogo_FullColor\.B1xPC0pSax\.svg/https:\/\/storage\.googleapis\.com\/instruqt-frontend\/assets\/hashicorp\/tracks\/vault\.png/' /home/vault/transit-app-example/backend/templates/base.html
+sed -i 's/112/60/' /home/vault/transit-app-example/backend/templates/base.html
+
 # Start the python web app
 cd /home/vault/transit-app-example/backend
 python3 app.py &>/dev/null &

--- a/instruqt-tracks/vault-encryption-as-a-service/track.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/track.yml
@@ -1,6 +1,6 @@
 slug: vault-encryption-as-a-service
 id: ykk2vp8iivzq
-version: 0.0.1
+version: 1.8.3
 type: track
 title: Vault Encryption as a Service
 teaser: |
@@ -118,7 +118,7 @@ challenges:
 
       You will add a record to the database and see that the data is not encrypted. The database user and password are hard-coded in a configuration file.
   assignment: |-
-    The web app can be viewed on the "Web App" tab. You'll want to click the icon in the upper right corner of the tabs area to hide the assignment window so that you can see the entire UI of the web app. Click it again to display the assignment window.
+    The web app can be viewed on the "Web App" tab. You might want to make your browser window wider or click the `>` icon above the assignment to hide the assignment so that you can see the entire UI of the web app. Click the `<` icon to redisplay the assignment window.
 
     The web app has two sections:
 
@@ -180,7 +180,7 @@ challenges:
 
     1. Change the first line of the "\[VAULT\]" section that has `Enabled = False` to `Enabled = True`.
     2. Change the next line that has `DynamicDBCreds = False` to `DynamicDBCreds = True`.
-    3. Then save the "config.ini" file.
+    3. Then save the "config.ini" file by clicking the disk icon above the file.
 
     <br>
     You should now restart the web app in the background with the following commands:
@@ -194,7 +194,7 @@ challenges:
 
     Note that the log will show a message like "using dynamic credentials from Vault: v-token-workshop-a-LcIkgRzHwTF2m with password A1a-U9QfaBp6hQaynvJy". This shows that the web app got dynamic, short-lived credentials from Vault's Database secrets engine. It then uses these to login to the MySQL server.
 
-    Return to the "Web App" tab and add another record. (Remember to click Instruqt's assignment toggle icon to hide the assignment so that you can see the "Add Record" button.) Then check that sensitive fields of the new record is encrypted in the Database View. In particular, the birth_date, social_security_number, address, and salary fields are all encrypted for the new record.
+    Return to the "Web App" tab and add another record. (Expand the width of your browser window or click Instruqt's `>` icon to hide the assignment if the "Add Record" button is not visible.) Then check that sensitive fields of the new record are encrypted in the Database View. In particular, the birth_date, social_security_number, address, and salary fields are all encrypted for the new record.
 
     Next, login to the Vault UI with token `root` and click on the "lob_a/workshop/transit" secrets engine on the Secrets tab of the Vault UI. Then click on the "customer-key" key. Then select the "Versions" tab. Rotate the key by clicking the "Rotate encryption key" button and confirming that you really want to rotate it by clicking "Rotate". You will now see two versions of the key.
 
@@ -219,4 +219,5 @@ challenges:
     path: /home/vault/transit-app-example/backend/config.ini
   difficulty: basic
   timelimit: 1200
-checksum: "16822224126488059853"
+checksum: "4149712714341855778"
+_: ""


### PR DESCRIPTION
Update version of Vault in most tracks to 1.8.3.
I did not update tracks that use Vault Enterprise since that would require addition of Vault Enterprise evaluation license which is more complicated.