### PR TITLE
update to Vault 1.9.2

### DIFF
--- a/instruqt-tracks/vault-aws-auth-method/config.yml
+++ b/instruqt-tracks/vault-aws-auth-method/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.8.3
+  image: vault:1.9.2
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-aws-auth-method/track.yml
+++ b/instruqt-tracks/vault-aws-auth-method/track.yml
@@ -1,6 +1,6 @@
 slug: vault-aws-auth-method
 id: fe9wq4sopgrc
-version: 1.8.3
+version: 1.9.2
 type: track
 title: AWS Auth Method for Vault
 teaser: Authenticate to Vault using the AWS Auth Method for IAM.
@@ -92,7 +92,8 @@ challenges:
   id: 4fnz9dgdhnfd
   type: challenge
   title: Configure the AWS IAM Auth Method
-  teaser: Configures the credentials required to perform successful API calls to AWS from Vault.
+  teaser: Configures the credentials required to perform successful API calls to AWS
+    from Vault.
   notes:
   - type: text
     contents: |-
@@ -195,7 +196,8 @@ challenges:
   id: cgaexaj1xjpe
   type: challenge
   title: Log In Using the AWS IAM Auth Method
-  teaser: Generate a signed AWS API request that will validate against AWS and log you into Vault.
+  teaser: Generate a signed AWS API request that will validate against AWS and log
+    you into Vault.
   notes:
   - type: text
     contents: |-
@@ -319,5 +321,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "2139607513904076653"
-_: ""
+checksum: "2414010682247345749"

--- a/instruqt-tracks/vault-basics/config.yml
+++ b/instruqt-tracks/vault-basics/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.8.3
+  image: vault:1.9.2
   cmd: version
   shell: /bin/sh -l
   ports:

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -1,6 +1,6 @@
 slug: vault-basics
 id: likpqjspv5pp
-version: 1.8.3
+version: 1.9.2
 type: track
 title: Vault Basics
 teaser: Learn how to setup and run a Vault server and manage its secrets.
@@ -432,5 +432,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 900
-checksum: "10671294877937963932"
-_: ""
+checksum: "13552750911339021265"

--- a/instruqt-tracks/vault-dynamic-database-credentials/config.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-1-8-3-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-9-2-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-dynamic-database-credentials/track.yml
+++ b/instruqt-tracks/vault-dynamic-database-credentials/track.yml
@@ -1,6 +1,6 @@
 slug: vault-dynamic-database-credentials
 id: hbtxgbf9n1nt
-version: 1.8.3
+version: 1.9.2
 type: track
 title: Vault Dynamic Database Credentials
 teaser: |
@@ -385,5 +385,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "2947793928319853135"
-_: ""
+checksum: "14731397102684341420"

--- a/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.8.3
+  image: vault:1.9.2
   cmd: version
   shell: /bin/sh
   ports:

--- a/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
+++ b/instruqt-tracks/vault-dynamic-secrets-aws/track.yml
@@ -1,6 +1,6 @@
 slug: vault-aws-dynamic-secrets
 id: avjxhl9qqgau
-version: 1.8.3
+version: 1.9.2
 type: track
 title: AWS Dynamic Secrets with Vault
 teaser: Generate AWS credentials dynamically based on IAM policies.
@@ -308,5 +308,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 300
-checksum: "17227856681745187198"
-_: ""
+checksum: "6452054047122448242"

--- a/instruqt-tracks/vault-encryption-as-a-service/config.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: vault-mysql-server
-  image: instruqt-hashicorp/vault-1-8-3-with-mysql-and-python-web-app
+  image: instruqt-hashicorp/vault-1-9-2-with-mysql-and-python-web-app
   shell: /bin/bash -l
   environment:
     MYSQL_ENDPOINT: localhost:3306

--- a/instruqt-tracks/vault-encryption-as-a-service/track.yml
+++ b/instruqt-tracks/vault-encryption-as-a-service/track.yml
@@ -1,6 +1,6 @@
 slug: vault-encryption-as-a-service
 id: ykk2vp8iivzq
-version: 1.8.3
+version: 1.9.2
 type: track
 title: Vault Encryption as a Service
 teaser: |
@@ -219,5 +219,4 @@ challenges:
     path: /home/vault/transit-app-example/backend/config.ini
   difficulty: basic
   timelimit: 1200
-checksum: "4149712714341855778"
-_: ""
+checksum: "7828581044459000849"

--- a/instruqt-tracks/vault-ssh-secrets-engine/enable-the-ssh-engine/setup-base
+++ b/instruqt-tracks/vault-ssh-secrets-engine/enable-the-ssh-engine/setup-base
@@ -9,7 +9,7 @@ sudo apt install sshpass
 ###########
 # Set Vault Version
 ###########
-vault_version="1.8.3"
+vault_version="1.9.2"
 
 ###########
 # Install Vault Client

--- a/instruqt-tracks/vault-ssh-secrets-engine/track.yml
+++ b/instruqt-tracks/vault-ssh-secrets-engine/track.yml
@@ -1,5 +1,6 @@
 slug: vault-ssh-secret-engine
 id: tkpmtwbzl1d8
+version: 1.9.2
 type: track
 title: Vault SSH Secret Engine
 teaser: Leverage Vault to secure SSH access to machines
@@ -16,6 +17,7 @@ tags:
 owner: hashicorp
 developers:
 - rcassidy@hashicorp.com
+- roger@hashicorp.com
 private: true
 published: true
 challenges:
@@ -26,7 +28,11 @@ challenges:
   teaser: Enable Vault's SSH secrets engine for signing keys.
   notes:
   - type: text
-    contents: In this challenge we will enable Vault's SSH engine for signing keys. The signed SSH certificates option is the simplest and most powerful in terms of setup complexity and in terms of being platform agnostic. By leveraging Vault's CA capabilities and functionality built into OpenSSH, clients can SSH into target hosts using their own local SSH keys.
+    contents: In this challenge we will enable Vault's SSH engine for signing keys.
+      The signed SSH certificates option is the simplest and most powerful in terms
+      of setup complexity and in terms of being platform agnostic. By leveraging Vault's
+      CA capabilities and functionality built into OpenSSH, clients can SSH into target
+      hosts using their own local SSH keys.
   assignment: |-
     First we need to enable the SSH secrets engine within Vault. Vault is already deployed and your token is configured as an environment variable.
 
@@ -74,7 +80,8 @@ challenges:
   id: lijvfy6qcihz
   type: challenge
   title: Sign Key with SSH Engine and SSH to Target
-  teaser: Use the SSH secrets engine set up in the previous challenge to sign a key and SSH to a target machine.
+  teaser: Use the SSH secrets engine set up in the previous challenge to sign a key
+    and SSH to a target machine.
   notes:
   - type: text
     contents: |-
@@ -252,5 +259,4 @@ challenges:
     port: 8200
   difficulty: basic
   timelimit: 1200
-checksum: "15607773902534503145"
-_: ""
+checksum: "10378879311439320648"


### PR DESCRIPTION
Update Vault workshop tracks to Vault 1.9.2
This does not update Vault ADP workshop tracks since those use Vault Enteprise and updating them would require adding licenses.