### PR TITLE
allow the use of relative paths when applying policy.

### DIFF
--- a/instruqt-tracks/vault-basics/vault-policies/check-vault-server
+++ b/instruqt-tracks/vault-basics/vault-policies/check-vault-server
@@ -2,9 +2,9 @@
 
 set -e
 
-grep -q "vault.*policy.*write.*/vault/policies/user-1-policy.hcl" /root/.bash_history || fail-message "You haven't added the first user policy yet."
+grep -q "vault.*policy.*write.*user-1-policy.hcl" /root/.bash_history || fail-message "You haven't added the first user policy yet."
 
-grep -q "vault.*policy.*write.*/vault/policies/user-2-policy.hcl" /root/.bash_history || fail-message "You haven't added the second user policy yet."
+grep -q "vault.*policy.*write.*user-2-policy.hcl" /root/.bash_history || fail-message "You haven't added the second user policy yet."
 
 grep -q "vault.*write.*auth/userpass/users/.*/policies.*policies=.*" /root/.bash_history || fail-message "You haven't updated the policies for your users yet."
 


### PR DESCRIPTION
This PR allows the check to pass regardless of whether the user used absolute and relative paths.

I ran this workshop yesterday and 2 attendees got stuck because they changed into the directory with the policies before editing and applying the policy.

I can't see any reason why the check shouldn't accept the use of relative paths when referencing policy files. 