### PR TITLE
Updating broken tutorial link

### DIFF
--- a/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
@@ -15,7 +15,7 @@ name: getting-started-with-instruqt
 # Instruqt로 실습하기
 * [Instruqt](https://instruqt.com/)은 HashiCorp 워크숍에 사용되는 플랫폼입니다.
 * Instruqt 랩은 "challenges"으로 구분 된 "tracks"에서 실행됩니다.
-* 이전에 Instruqt를 사용한 적이 없다면이 [튜토리얼](https://docs.instruqt.com/)으로 시작하세요.
+* 이전에 Instruqt를 사용한 적이 없다면이 [튜토리얼](https://play.instruqt.com/embed/instruqt/tracks/getting-started-with-instruqt?token=em_dw5tjnqsditbcdps&show_challenges=true)으로 시작하세요.
 * 그렇지 않으면 다음 슬라이드로 건너 뛸 수 있습니다.
 * 이 "Vault Basic"실습에서는 2-6 장에 소개 된 개념을 다룹니다.
 

--- a/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/korean/multi-cloud/vault-oss/vault-basics-lab.md
@@ -15,7 +15,7 @@ name: getting-started-with-instruqt
 # Instruqt로 실습하기
 * [Instruqt](https://instruqt.com/)은 HashiCorp 워크숍에 사용되는 플랫폼입니다.
 * Instruqt 랩은 "challenges"으로 구분 된 "tracks"에서 실행됩니다.
-* 이전에 Instruqt를 사용한 적이 없다면이 [튜토리얼](https://play.instruqt.com/instruqt/tracks/getting-started-with-instruqt)으로 시작하세요.
+* 이전에 Instruqt를 사용한 적이 없다면이 [튜토리얼](https://docs.instruqt.com/)으로 시작하세요.
 * 그렇지 않으면 다음 슬라이드로 건너 뛸 수 있습니다.
 * 이 "Vault Basic"실습에서는 2-6 장에 소개 된 개념을 다룹니다.
 

--- a/docs/slides/multi-cloud/adp/index.md
+++ b/docs/slides/multi-cloud/adp/index.md
@@ -272,7 +272,7 @@ background-image: url(images/HashiCorp-Title-bkg.jpeg)
 # Doing Labs with Instruqt
 * Instruqt is the platform used for HashiCorp's workshops
 * Instruqt labs are run in “tracks” that are divided into “challenges”
-* If you’ve never used Instruqt before, start with this **[tutorial](https://play.instruqt.com/instruqt/tracks/getting-started-with-instruqt)**
+* If you’ve never used Instruqt before, start with this **[tutorial](https://docs.instruqt.com/)**
 * Otherwise, you can skip to the next slide
 
 ---

--- a/docs/slides/multi-cloud/adp/index.md
+++ b/docs/slides/multi-cloud/adp/index.md
@@ -272,7 +272,7 @@ background-image: url(images/HashiCorp-Title-bkg.jpeg)
 # Doing Labs with Instruqt
 * Instruqt is the platform used for HashiCorp's workshops
 * Instruqt labs are run in “tracks” that are divided into “challenges”
-* If you’ve never used Instruqt before, start with this **[tutorial](https://docs.instruqt.com/)**
+* If you’ve never used Instruqt before, start with this **[tutorial](https://play.instruqt.com/embed/instruqt/tracks/getting-started-with-instruqt?token=em_dw5tjnqsditbcdps&show_challenges=true)**
 * Otherwise, you can skip to the next slide
 
 ---

--- a/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
@@ -15,7 +15,7 @@ name: getting-started-with-instruqt
 # Doing Labs with Instruqt
 * [Instruqt](https://instruqt.com/) is the platform used for HashiCorp workshops.
 * Instruqt labs are run in "tracks" that are divided into "challenges".
-* If you've never used Instruqt before, start with this [tutorial](https://play.instruqt.com/instruqt/tracks/getting-started-with-instruqt).
+* If you've never used Instruqt before, start with this [tutorial](https://docs.instruqt.com/).
 * Otherwise, you can skip to the next slide.
 * This "Vault Basics" lab covers concepts introduced in chapters 2-6.
 * Your instructor will provide links to the tracks.

--- a/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
+++ b/docs/slides/multi-cloud/vault-oss/vault-basics-lab.md
@@ -15,7 +15,7 @@ name: getting-started-with-instruqt
 # Doing Labs with Instruqt
 * [Instruqt](https://instruqt.com/) is the platform used for HashiCorp workshops.
 * Instruqt labs are run in "tracks" that are divided into "challenges".
-* If you've never used Instruqt before, start with this [tutorial](https://docs.instruqt.com/).
+* If you've never used Instruqt before, start with this [tutorial](https://play.instruqt.com/embed/instruqt/tracks/getting-started-with-instruqt?token=em_dw5tjnqsditbcdps&show_challenges=true).
 * Otherwise, you can skip to the next slide.
 * This "Vault Basics" lab covers concepts introduced in chapters 2-6.
 * Your instructor will provide links to the tracks.


### PR DESCRIPTION
Instruqt tutorial link is broken in the workshop. Updated tutorial link to https://docs.instruqt.com/ which provides a platform overview for learners