### PR TITLE
chore: vault binary version bump

### DIFF
--- a/instruqt-tracks/vault-basics/config.yml
+++ b/instruqt-tracks/vault-basics/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: vault-server
-  image: vault:1.9.2
+  image: hashicorp/vault:1.13
   cmd: version
   shell: /bin/sh -l
   ports:

--- a/instruqt-tracks/vault-basics/track.yml
+++ b/instruqt-tracks/vault-basics/track.yml
@@ -1,6 +1,6 @@
 slug: vault-basics
 id: likpqjspv5pp
-version: 1.9.2
+version: 1.13.1
 type: track
 title: Vault Basics
 teaser: Learn how to setup and run a Vault server and manage its secrets.


### PR DESCRIPTION
Vault binary version update from 1.9.2 to 1.13.1